### PR TITLE
Update schema & utility function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
+export * from "./src/extract-values.js";
 export * as typebox from "./src/typebox.js";
 export * as zod from "./src/zod.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@substreams/sink-database-changes",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@substreams/sink-database-changes",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "latest",

--- a/src/extract-values.ts
+++ b/src/extract-values.ts
@@ -1,0 +1,9 @@
+import { TableChange } from "./zod.js";
+
+export function getValuesInTableChange(change: TableChange) {
+  const values: Record<string, unknown> = {};
+  for (const field of change.fields) {
+    values[field.name] = field.newValue;
+  }
+  return values;
+}

--- a/src/typebox.test.ts
+++ b/src/typebox.test.ts
@@ -2,6 +2,6 @@ import { test } from "vitest";
 import { PrimaryKey } from "./typebox.js";
 
 test("PrimaryKey", () => {
-    ({ id: "1" }) as PrimaryKey;
-    ({ compositePk: {keys: [["1", "2"]]} }) as PrimaryKey;
+  ({ pk: "1" }) as PrimaryKey;
+  ({ compositePk: { keys: [["1", "2"]] } }) as PrimaryKey;
 });

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -19,30 +19,21 @@ export const CompositePrimaryKey = Type.Object({
 
 export const PrimaryKey = Type.Union([
   Type.Object({
-    id: Type.String(),
+    pk: Type.String(),
   }),
   Type.Object({
     compositePk: CompositePrimaryKey,
-  })
+  }),
 ]);
 
-export const TableChange = Type.Union([
-  // Simple primary key
+export const TableChange = Type.Intersect([
   Type.Object({
     table: Type.String(),
-    id: Type.String(),
-    ordinal: Type.Number(),
+    ordinal: Type.String(),
     operation: TableChangeOperation,
     fields: Type.Array(Field),
   }),
-  // Composite primary key
-  Type.Object({
-    table: Type.String(),
-    compositePk: CompositePrimaryKey,
-    ordinal: Type.Number(),
-    operation: TableChangeOperation,
-    fields: Type.Array(Field),
-  }),
+  PrimaryKey,
 ]);
 
 export const DatabaseChanges = Type.Object({

--- a/src/zod.test.ts
+++ b/src/zod.test.ts
@@ -2,6 +2,6 @@ import { test } from "vitest";
 import { PrimaryKey } from "./zod.js";
 
 test("PrimaryKey", () => {
-    ({ id: "1" }) as PrimaryKey;
-    ({ compositePk: {keys: [["1", "2"]]} }) as PrimaryKey;
+  ({ pk: "1" }) as PrimaryKey;
+  ({ compositePk: { keys: [["1", "2"]] } }) as PrimaryKey;
 });

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -19,31 +19,21 @@ export const CompositePrimaryKey = z.object({
 
 export const PrimaryKey = z.union([
   z.object({
-    id: z.string(),
+    pk: z.string(),
   }),
   z.object({
     compositePk: CompositePrimaryKey,
-  })
+  }),
 ]);
 
-export const TableChange = z.union([
-  // Simple primary key
-  z.object({
+export const TableChange = z
+  .object({
     table: z.string(),
-    id: z.string(),
-    ordinal: z.number(),
-    operation: TableChangeOperation,
-    fields: z.array(Field),
-  }),
-  // Composite primary key
-  z.object({
-    table: z.string(),
-    compositePk: CompositePrimaryKey,
-    ordinal: z.number(),
+    ordinal: z.string().transform((str) => parseInt(str)),
     operation: TableChangeOperation,
     fields: z.array(Field),
   })
-]);
+  .and(PrimaryKey);
 
 export const DatabaseChanges = z.object({
   tableChanges: z.array(TableChange),


### PR DESCRIPTION
Updated the schema to comply with the expected data.
Added utility function to reduce `newValue` into a single object (from a table change)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `PrimaryKey` and `TableChange` types in the codebase. 

### Detailed summary
- Renamed the `id` property to `pk` in the `PrimaryKey` type in both `typebox.ts` and `zod.ts` files.
- Updated the `TableChange` type to be an intersection of objects in `typebox.ts` file.
- Added a new function `getValuesInTableChange` in `extract-values.ts` file.
- Updated the version number in `package-lock.json` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->